### PR TITLE
Remove PIL dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ VideoCut supports the cutting of subtitles when "Show subtitles"  in the setting
 The current version is written in python3 and uses the qt5 widget kit.  
 
 ### Prerequisites
-* Arch: python3, python-pillow and mpv
-* Debian/Mint/Ubuntu: python3 python3-pil libmpv1 python3-pyqt5.qtopengl (no-recommends)
+* Arch: python3 and mpv
+* Debian/Mint/Ubuntu: python3 libmpv1 python3-pyqt5.qtopengl (no-recommends)
   #not working for Ubuntu 18.4: libmpv - use python3-opencv instead
-* Fedora: python3-pillow-qt and mpv-libs.x86_64
+* Fedora: mpv-libs.x86_64
 * ffmpeg > 3.X to 5.X
 * python3-pyqt5
 * optional:(legacy) OpenCV 2.4 up to OpenCV 4.x (must be build with ffmpeg - with all its dependencies)
@@ -125,13 +125,13 @@ Select video and open it with "Open with ->VideoCut", oder via terminal "VideoCu
 
 #### Install dependencies manually on Linux Mint or Ubuntu (tested from 20.04 to 22.04)
 ```
-sudo apt –no-install-recommends install python3-pyqt5 ffmpeg python3-pil libmpv1
+sudo apt –no-install-recommends install python3-pyqt5 ffmpeg libmpv1
 ```
 libmpv1 won't work on Ubuntu 18.04 - no bindings for the old libs - use opencv instead
 
 #### Install dependencies on Fedora
 ```
-sudo dnf python3-qt5 ffmpeg python3-pillow-qt mpv-libs.x86_64
+sudo dnf python3-qt5 ffmpeg mpv-libs.x86_64
 ```
 
 ### How to install with a terminal

--- a/build/install.sh
+++ b/build/install.sh
@@ -11,10 +11,10 @@ sudo mkdir -p /opt/videocut;
 sudo cp -r $DIR/* /opt/videocut/;
 sudo ln -s /opt/videocut/VideoCut.py /usr/bin/VideoCut
 
-echo "######################################################################"
-echo "#                  Ensure you have installed:                        #"                     
-echo "#    debian/ubuntu/mint: python3-pyqt5 ffmpeg python3-pil libmpv1    #"
-echo "#    arch &derivates:    python-pyqt5 ffmpeg python-pillow mpv       #"
-echo "######################################################################"
+echo "##########################################################"
+echo "#               Ensure you have installed:               #"
+echo "#    debian/ubuntu/mint: python3-pyqt5 ffmpeg libmpv1    #"
+echo "#    arch &derivates:    python-pyqt5  ffmpeg mpv        #"
+echo "##########################################################"
 
 echo "App installed."

--- a/src/MpvPlayer.py
+++ b/src/MpvPlayer.py
@@ -19,7 +19,6 @@ import locale
 
 
 from PyQt5.QtOpenGL import QGLContext    
-from PIL.ImageQt import ImageQt #Not there by default...
 from lib.mpv import (MPV,MpvGlGetProcAddressFn,MpvRenderContext,MpvEventEndFile)
     
 
@@ -348,8 +347,7 @@ class MpvPlayer():
         return self.screenshotImage()
     
     def screenshotImage(self):
-        im=self.mediaPlayer.screenshot_raw(includes="video")
-        return ImageQt(im)#scale? ==QImage        
+        return self.mediaPlayer.screenshot_raw(includes="video")
 
     def takeScreenShot(self,path):
         self.mediaPlayer.screenshot_to_file(path,includes="video")
@@ -589,13 +587,13 @@ class MpvPlugin():
     def setCutEntry(self,cutEntry,restore=False): #this is a cv restore hack
         if restore: #legacy: create a pix from old entry 
             cutEntry.frameNumber=cutEntry.frameNumber-1 #cv compensation
-            pilImage = self.player.screenshotAtFrame(cutEntry.frameNumber)
+            qImage = self.player.screenshotAtFrame(cutEntry.frameNumber)
         else: #create a new one
-            pilImage = self.player.screenshotImage()
+            qImage = self.player.screenshotImage()
 
             #set: cutEntry.frameNumber=self.player.getCurrentFrameNumber()    
         cutEntry.timePosMS=self.player.timePos()*1000 #Beware +1!
-        cutEntry.pix = self._makeThumbnail(pilImage)
+        cutEntry.pix = self._makeThumbnail(qImage)
     
     def info(self):
         data={}

--- a/src/lib/focal/mpv.py
+++ b/src/lib/focal/mpv.py
@@ -716,46 +716,6 @@ class GeneratorStream:
         # TODO?
 
 
-class ImageOverlay:
-    def __init__(self, m, overlay_id, img=None, pos=(0, 0)):
-        self.m = m
-        self.overlay_id = overlay_id
-        self.pos = pos
-        self._size = None
-        if img is not None:
-            self.update(img)
-
-    def update(self, img=None, pos=None):
-        from PIL import Image
-        if img is not None:
-            self.img = img
-        img = self.img
-
-        w, h = img.size
-        stride = w*4
-
-        if pos is not None:
-            self.pos = pos
-        x, y = self.pos
-
-        # Pre-multiply alpha channel
-        bg = Image.new('RGBA', (w, h),  (0, 0, 0, 0))
-        out = Image.alpha_composite(bg, img)
-
-        # Copy image to ctypes buffer
-        if img.size != self._size:
-            self._buf = create_string_buffer(w*h*4)
-            self._size = img.size
-
-        ctypes.memmove(self._buf, out.tobytes('raw', 'BGRA'), w*h*4)
-        source = '&' + str(addressof(self._buf))
-
-        self.m.overlay_add(self.overlay_id, x, y, source, 0, 'bgra', w, h, stride)
-
-    def remove(self):
-        self.m.remove_overlay(self.overlay_id)
-
-
 class FileOverlay:
     def __init__(self, m, overlay_id, filename=None, size=None, stride=None, pos=(0,0)):
         self.m = m
@@ -1093,15 +1053,17 @@ class MPV(object):
         self.command('screenshot_to_file', filename.encode(fs_enc), includes)
 
     def screenshot_raw(self, includes='subtitles'):
-        """Mapped mpv screenshot_raw command, see man mpv(1). Returns a pillow Image object."""
-        from PIL import Image
+        """Mapped mpv screenshot_raw command, see man mpv(1). Returns a PyQt QImage object."""
+        from PyQt5.QtGui import QImage
         res = self.node_command('screenshot-raw', includes)
         if res['format'] != 'bgr0':
             raise ValueError('Screenshot in unknown format "{}". Currently, only bgr0 is supported.'
                     .format(res['format']))
-        img = Image.frombytes('RGBA', (res['stride']//4, res['h']), res['data'])
-        b,g,r,a = img.split()
-        return Image.merge('RGB', (r,g,b))
+        # Read the BGR0 as RGBA, swap R and B so they are correct, and then remove the alpha
+        img = QImage(res['data'], res['stride']//4, res['h'], res['stride'], QImage.Format_RGBA8888) \
+                  .rgbSwapped() \
+                  .convertToFormat(QImage.Format_RGB32)
+        return img
 
     def allocate_overlay_id(self):
         free_ids = set(range(64)) - self.overlay_ids
@@ -1117,12 +1079,6 @@ class MPV(object):
     def create_file_overlay(self, filename=None, size=None, stride=None, pos=(0,0)):
         overlay_id = self.allocate_overlay_id()
         overlay = FileOverlay(self, overlay_id, filename, size, stride, pos)
-        self.overlays[overlay_id] = overlay
-        return overlay
-
-    def create_image_overlay(self, img=None, pos=(0,0)):
-        overlay_id = self.allocate_overlay_id()
-        overlay = ImageOverlay(self, overlay_id, img, pos)
         self.overlays[overlay_id] = overlay
         return overlay
 


### PR DESCRIPTION
PIL v10+ [no longer supports PyQt5](https://github.com/python-pillow/Pillow/commit/59c9d87f8a4d8443a482ca7abb5f1f8d5d970cbd#diff-e515c654cff3147b68f4a9ee9123107b8214d1d85fbdce486a0d570ff00eef38). Since it is only used for some screenshot functions, replace it with QImage. The `ImageOverlay` class is unused and I had no way of testing it, so I just removed it.