### PR TITLE
Add FFmpeg v7 support to remux

### DIFF
--- a/build/AUR-template/PKGBUILD
+++ b/build/AUR-template/PKGBUILD
@@ -11,8 +11,7 @@ source=(https://github.com/kanehekili/VideoCut/releases/download/@xxx@/videocut@
 md5sums=(@md5sum@)
 
 build() {
-make -C ${pkgname}/ffmpeg/src/ -f makefile
-make -C ${pkgname}/ffmpeg/src/ -f makefile clean
+  make -C ${pkgname}/ffmpeg/src/ -f makefile all clean
 }
 
 package(){	
@@ -22,8 +21,7 @@ package(){
   mkdir -p "${pkgdir}/usr/bin"
   rm  $srcdir/$pkgname/install.sh
   rm  $srcdir/$pkgname/uninstall.sh
-  rm -rf  $srcdir/$pkgname/ffmpeg/bin/V3/
-  rm -rf  $srcdir/$pkgname/ffmpeg/bin/V4/
+  rm -rf  $srcdir/$pkgname/ffmpeg/bin/V*/
   cp  $srcdir/$pkgname/VideoCut.desktop "${pkgdir}/usr/share/applications"
   cp -r $srcdir/$pkgname/* "${pkgdir}/opt/${pkgname}"
   ln -s /opt/videocut/VideoCut.py  ${pkgdir}/usr/bin/videocut

--- a/build/DEB-template/makefile
+++ b/build/DEB-template/makefile
@@ -1,10 +1,4 @@
-remux5: remux5.o
-	gcc -o src/ffmpeg/bin/remux5 remux5.o -g -lavutil -lavformat -lavcodec 
+all clean:
+	$(MAKE) -C src/ffmpeg/src/ $@
 
-remux5.o: src/ffmpeg/src/remux5.c
-	gcc -c src/ffmpeg/src/remux5.c 
-
-.PHONY: clean
-
-clean:
-	rm -f *.o remux5
+.PHONY: all clean

--- a/src/ffmpeg/readme.txt
+++ b/src/ffmpeg/readme.txt
@@ -8,15 +8,10 @@ Tested on debian buster,Linux Mint and Ubuntu, as well as Fedora, propably on ot
 
 Is activ by setting the "VideoCut Muxer" switch to on.(Toolbar ->Clogs icon)
 
-Makefile:
-remux5: remux5.o
-	gcc  -o ../bin/V4/remux5 remux5.o -g -lavutil -lavformat -lavcodec 
+The src directory contains a makefile, simply run "make" to build the executable.
 
-remux5.o: remux5.c
-	gcc -c remux5.c 
- 
 On debian derivates follwing packes are needed to compile_
- sudo apt-get install build-essential cmake git libgtk2.0-dev pkg-config libavcodec-dev libavformat-dev libswscale-dev
+ sudo apt-get install make gcc libavcodec-dev libavformat-dev
  
  The binary may be used without VideoCut. The parameters:
  remux5 inputFile outputFile -s ts1,ts2,ts3,ts4...

--- a/src/ffmpeg/src/makefile
+++ b/src/ffmpeg/src/makefile
@@ -1,10 +1,12 @@
-remux5: remux5.o
-	gcc -o ../bin/remux5 remux5.o -g -lavutil -lavformat -lavcodec 
+CFLAGS += -g
+LDLIBS += -lavcodec -lavformat -lavutil
 
-remux5.o: remux5.c
-	gcc -c remux5.c 
+all: ./../bin/remux5
 
-.PHONY: clean
+./../bin/remux5: remux5
+	cp $< $@
+
+.PHONY: all clean
 
 clean:
 	rm -f *.o remux5

--- a/src/ffmpeg/src/remux5.c
+++ b/src/ffmpeg/src/remux5.c
@@ -22,20 +22,20 @@
  */
 
 /*
-  * Versions supported: (libavutil/version.h)
-  * ffmpeg 3.4.2
-  * #define LIBAVCODEC_VERSION_MAJOR  57	 	
-  * #define LIBAVCODEC_VERSION_MINOR 107
-  * 
-  * ffmpeg 4.x
-  * #define LIBAVCODEC_VERSION_MAJOR  58
-  * #define LIBAVCODEC_VERSION_MINOR 18
-  *
-  * ffmpeg 5
-  * #define FF_API_OLD_CHANNEL_LAYOUT   (LIBAVUTIL_VERSION_MAJOR < 58)
-  * else: #include <libavutil/channel_layout.h>
-  * ?ffmpg6
-  */
+ * Versions supported:
+ * ffmpeg 3.4.x  LIBAVCODEC_VERSION_MAJOR=57 _MINOR=107
+ * ffmpeg 4.x    LIBAVCODEC_VERSION_MAJOR=58
+ * ffmpeg 5.x    LIBAVCODEC_VERSION_MAJOR=59
+ * ffmpeg 6.x    LIBAVCODEC_VERSION_MAJOR=60
+ */
+#include <libavcodec/version.h>
+#if (LIBAVCODEC_VERSION_MAJOR < 57)
+  #error "Ffmpeg 3.4 or newer is required"
+#endif
+#if (LIBAVCODEC_VERSION_MAJOR == 57)
+  #define FFMPEG_REGISTER 1
+#endif
+
 #include <libavutil/timestamp.h>
 #include <libavformat/avformat.h>
 #include <libavcodec/avcodec.h>
@@ -46,12 +46,6 @@
 #include <sys/sysinfo.h>
 #include <stdio.h>
 
-#if (LIBAVCODEC_VERSION_MAJOR == 57)
-#define FFMPEG_REGISTER 1
-#endif
-#if (LIBAVCODEC_VERSION_MAJOR < 57)
-#error "Ffmpeg 3.4 or newer is required"
-#endif 
 #define max(a,b) (a>b?a:b)
 #define min(a,b) (a<b?a:b)
 #define round(x) ((x)>=0?(long)((x)+0.5):(long)((x)-0.5))

--- a/src/ffmpeg/src/remux5.c
+++ b/src/ffmpeg/src/remux5.c
@@ -27,6 +27,7 @@
  * ffmpeg 4.x    LIBAVCODEC_VERSION_MAJOR=58
  * ffmpeg 5.x    LIBAVCODEC_VERSION_MAJOR=59
  * ffmpeg 6.x    LIBAVCODEC_VERSION_MAJOR=60
+ * ffmpeg 7.x    LIBAVCODEC_VERSION_MAJOR=61
  */
 #include <libavcodec/version.h>
 #if (LIBAVCODEC_VERSION_MAJOR < 57)
@@ -34,6 +35,15 @@
 #endif
 #if (LIBAVCODEC_VERSION_MAJOR == 57)
   #define FFMPEG_REGISTER 1
+#endif
+#if (LIBAVCODEC_VERSION_MAJOR <= 60)
+  #define AVCODECPARAMETERS_CHANNELS channels
+  #define AVFRAME_PKTDURATION pkt_duration
+  #define AVCODECCONTEXT_FRAMENUMBER frame_number
+#else
+  #define AVCODECPARAMETERS_CHANNELS ch_layout.nb_channels
+  #define AVFRAME_PKTDURATION duration
+  #define AVCODECCONTEXT_FRAMENUMBER frame_num
 #endif
 
 #include <libavutil/timestamp.h>
@@ -194,9 +204,7 @@ static int _collectAllStreams(){
     	        return -1;
     	    }
     	}else if (in_codecpar->codec_type == AVMEDIA_TYPE_AUDIO){
-           int channels = in_codecpar->channels;
-			//LIBAVUTIL_VERSION_MAJOR > 57
-            //int channels= in_codecpar->ch_layout>nb_channels;
+           int channels = in_codecpar->AVCODECPARAMETERS_CHANNELS;
             int sr = in_codecpar->sample_rate;
         	currLang = av_dict_get(ifmt_ctx->streams[i]->metadata, "language", NULL,0);
         	int audioIndex= currLang!=NULL?getLanguageIndex(currLang->value):-1;
@@ -1325,7 +1333,7 @@ static int flushFrames(struct StreamInfo *info, AVFrame *frame){
                 int ret2;
                 ret2=avcodec_send_frame(info->out_codec_ctx,frame);
                 if (ret2==0){
-                    av_log(NULL, AV_LOG_VERBOSE,"flush Frame sent: P:%ld dur:%ld\n",frame->pts,frame->pkt_duration);
+                    av_log(NULL, AV_LOG_VERBOSE,"flush Frame sent: P:%ld dur:%ld\n",frame->pts,frame->AVFRAME_PKTDURATION);
                     AVPacket enc_pkt;
                     enc_pkt.data = NULL;
                     enc_pkt.size = 0;
@@ -1503,7 +1511,7 @@ static int transcode( int64_t start, int64_t stop){
 				char ptype = av_get_picture_type_char(frame->pict_type);
 				double_t fptime= av_q2d(info->inStream->time_base)*(pts);
 				//DTS is always==PTS- since its decoded...
-				av_log(NULL, AV_LOG_VERBOSE,"[%d]%d) decode key: %d (%d) type: %c, pts: %ld time: %.3f frm dur %ld",frame->coded_picture_number,info->in_codec_ctx->frame_number,frame->key_frame,pkt.flags,ptype,pts,fptime,frame->pkt_duration);
+				av_log(NULL, AV_LOG_VERBOSE,"%d) decode key: %d (%d) type: %c, pts: %ld time: %.3f frm dur %ld",info->in_codec_ctx->AVCODECCONTEXT_FRAMENUMBER,frame->key_frame,pkt.flags,ptype,pts,fptime,frame->AVFRAME_PKTDURATION);
         	}
 			//if (frame->pts != AV_NOPTS_VALUE && frame->pts < start){
             if (pts < tcStart){
@@ -1666,7 +1674,7 @@ static int dumpDecodingData(){
                 char ptype = av_get_picture_type_char(frame->pict_type);
                 double_t fptime= av_q2d(streamInfo->outStream->time_base)*(frame->pts - streamInfo->inStream->start_time);  
                 //DTS is always==PTS- since its decoded...
-                av_log(NULL, AV_LOG_INFO,"%d)FRM key: %d(%d) type:%c,pts:%ld time:%.3f\n",streamInfo->in_codec_ctx->frame_number,frame->key_frame,pkt.flags,ptype,frame->pts,fptime);
+                av_log(NULL, AV_LOG_INFO,"%d)FRM key: %d(%d) type:%c,pts:%ld time:%.3f\n",streamInfo->in_codec_ctx->AVCODECCONTEXT_FRAMENUMBER,frame->key_frame,pkt.flags,ptype,frame->pts,fptime);
             }else {
                 double_t dtime= av_q2d(streamInfo->outStream->time_base)*(pkt.dts - streamInfo->inStream->start_time);  
                 av_log(NULL, AV_LOG_INFO,"Buffer pkt: isKey:%d p:%ld d:%ld [%.3f]\n",pkt.flags, pkt.pts,pkt.dts,dtime);            


### PR DESCRIPTION
The `remux` tool requires slight modification to work the recently released FFmpeg v7, because some previously deprecated members and fields were finally removed. It isn't too much, and rather straight forward. I confirmed it compiles and works with FFmpeg v7, and also compiles with v4, v5 and v6.

Since I was working in that corner, I took notice of that little mess which is the building processes for that tool. I took the liberty to consolidate, clean up and improve it.