### PR TITLE
Use correct fps mpv option

### DIFF
--- a/src/MpvPlayer.py
+++ b/src/MpvPlayer.py
@@ -386,7 +386,8 @@ class MpvPlayer():
         self.fps=newFPS
         self.framecount=self.duration*newFPS #framecount prop not reliable
         #often a difference between the mpv fps and the fmmpeg fps
-        self.mediaPlayer["fps"]=newFPS
+        property_name='container-fps-override' if self.mediaPlayer.mpv_version_tuple >= (0,39,0) else 'fps'
+        self.mediaPlayer[property_name]=newFPS
     
     '''            
     def _onFps(self,name,val):


### PR DESCRIPTION
In mpv 0.37.0 the `fps` option was renamed to `container-fps-override` [0][1], and a compatibility alias was added so both the new and old names worked. In the recently released mpv 0.39.0 that compatibility alias was removed [2][3], using the old name does not work any more.

Since VideoCut is currently using the old name, it does currently not work with the latest mpv release. The error(s) you get are:
```
Traceback (most recent call last):
  File "/tmp/VideoCut/src/lib/mpv.py", line 902, in _enqueue_exceptions
    yield
  File "/tmp/VideoCut/src/lib/mpv.py", line 931, in _loop
    handler(name, value)
  File "/tmp/VideoCut/src/MpvPlayer.py", line 461, in _onReadyWait
    self.setFPS(val)
  File "/tmp/VideoCut/src/MpvPlayer.py", line 389, in setFPS
    self.mediaPlayer["fps"]=newFPS
    ~~~~~~~~~~~~~~~~^^^^^^^
  File "/tmp/VideoCut/src/lib/mpv.py", line 2104, in __setitem__
    return self._set_property(prefix+name, value)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/VideoCut/src/lib/mpv.py", line 2074, in _set_property
    _mpv_set_property_string(self.handle, ename, _mpv_coax_proptype(value))
  File "/tmp/VideoCut/src/lib/mpv.py", line 142, in raise_for_ec
    raise ex
AttributeError: ('mpv property does not exist', -8, (<MpvHandle object at 0x7fb08afc0150>, b'options/fps', b'1.0'))
```
```
Traceback (most recent call last):
*  File "/tmp/VideoCut/src/VideoCut.py", line 676, in __queueStarted
    self._videoController.prepare()
*  File "/tmp/VideoCut/src/VideoCut.py", line 1351, in prepare
    VideoPlugin.showBanner()
*  File "/tmp/VideoCut/src/MpvPlayer.py", line 672, in showBanner
    self.initPlayer("icons/film-clapper.png",None)
*  File "/tmp/VideoCut/src/MpvPlayer.py", line 554, in initPlayer
    raise Exception(self.player.lastError)
*Exception
```

mpv 0.37.0 was released in November 2023, so it is less than a year old. Most distributions (like Debian stable) ship a mpv version that requires the old name, while other (like Arch) already ship a version that requires the new name, which makes it necessary to support both names for now.

The solution is a simple version check to decide which name to use. I choose 0.39.0 as the switch-over point, as to not change the current behaviour.

[0] https://github.com/mpv-player/mpv/blob/release/0.37/DOCS/interface-changes.rst?plain=1#L103
[1] https://github.com/mpv-player/mpv/commit/7aed492ccc48fd32084d7dfe65a50b5b90d8411a
[2] https://github.com/mpv-player/mpv/blob/release/0.39/DOCS/interface-changes.rst?plain=1#L41
[3] https://github.com/mpv-player/mpv/commit/6e3d90d72a995bfb8b91d79538dd354c6221d527