### PR TITLE
Keep ui_Slider always enabled

### DIFF
--- a/src/VideoCut.py
+++ b/src/VideoCut.py
@@ -490,7 +490,6 @@ class LayoutWindow(QWidget):
 
     def enableUserActions(self, enable):
         self.ui_Dial.setEnabled(enable)
-        self.ui_Slider.setEnabled(enable)
         self.gotoAction.setEnabled(enable)
         self.ui_GotoField.setEnabled(enable)
 


### PR DESCRIPTION
Fixes #42 

Tested it and it works, no problem. I need it because TV recordings I do are showing artefacts and it needs some small playtime to get visible image.